### PR TITLE
feat: add basic auth

### DIFF
--- a/main/r4sGate.h
+++ b/main/r4sGate.h
@@ -313,6 +313,8 @@ char MyJPGbuf[MyJPGbuflen];
 int32_t MyJPGbufidx = 0;
 char tESP32Addr[16];                        //esp mac
 
+char AUTH_BASIC[51];
+
 uint8_t R4SNUM = 0;                         //r4s number
 uint8_t R4SNUMO = 0;                        //r4s number
 //uint8_t r4ststat = 0;                     //timer?


### PR DESCRIPTION
Добавлена настройка для включения basic авторизации

в настройка добавлено поле для ввода закодированных логина и пароля

![image](https://user-images.githubusercontent.com/731779/164711841-a6964d57-d4ce-4ec4-b5c9-8cea2a4c1890.png)

как получить закодированные логина и пароля:
пишем логин и пароль через двоеточие `login:password` и эту строку кодируем в base64

![image](https://user-images.githubusercontent.com/731779/164712045-42851a85-0f9a-4650-95e8-93a91c80b238.png)

после этого на всех страницах будет предложение ввести пароль

![image](https://user-images.githubusercontent.com/731779/164712141-e589999c-c91a-4d5d-980c-4cf8869f213f.png)

возможно стоит вывести его в лог при загрузке (не сделано).

так же просьба проверить правильность длин буферов для пароля и поля в nvs (на `C` не пишу, мог ошибиться)
